### PR TITLE
add multi-language code blocks to getting started guide

### DIFF
--- a/docs/getting_started/configuration.mdx
+++ b/docs/getting_started/configuration.mdx
@@ -2,11 +2,16 @@
 title: Configuration
 sidebar_position: 2
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 For our first example, we are going to compose a GraphQL schema from the REST APIs at <a href="https://jsonplaceholder.typicode.com" target="_blank">https://jsonplaceholder.typicode.com</a>, a free online REST API with some fake data.
 We will use the API at `/users` to get a list of users, and `/users/:id/posts` to get the posts for each user, and compose them into a single GraphQL schema.
 
-Create a file called `jsonplaceholder.graphql` and paste the following contents into it.
+Create one of the following files and paste the contents into it.
+
+<Tabs>
+<TabItem value="graphql" label="jsonplaceholder.graphql">
 
 ```graphql showLineNumbers
 schema
@@ -41,5 +46,153 @@ type Post {
   body: String!
 }
 ```
+
+</TabItem>
+<TabItem value="yml" label="jsonplaceholder.yml">
+
+```yml showLineNumbers 
+server:
+  port: 8000
+  graphiql: true
+  queryValidation: false
+  hostname: "0.0.0.0"
+upstream:
+  baseURL: "http://jsonplaceholder.typicode.com"
+  httpCache: true
+schema:
+  query: Query
+types:
+  Post:
+    fields:
+      body:
+        type: String
+        required: true
+      id:
+        type: Int
+        required: true
+      title:
+        type: String
+        required: true
+      user:
+        type: User
+        http:
+          path: /users/{{value.userId}}
+      userId:
+        type: Int
+        required: true
+  Query:
+    fields:
+      posts:
+        type: Post
+        list: true
+        http:
+          path: /posts
+  User:
+    fields:
+      email:
+        type: String
+        required: true
+      id:
+        type: Int
+        required: true
+      name:
+        type: String
+        required: true
+      phone:
+        type: String
+      username:
+        type: String
+        required: true
+      website:
+        type: String
+```
+
+</TabItem>
+<TabItem value="json" label="jsonplaceholder.json">
+
+```json showLineNumbers
+{
+  "server": {
+    "port": 8000,
+    "graphiql": true,
+    "queryValidation": false,
+    "hostname": "0.0.0.0"
+  },
+  "upstream": {
+    "baseURL": "http://jsonplaceholder.typicode.com",
+    "httpCache": true
+  },
+  "schema": {
+    "query": "Query"
+  },
+  "types": {
+    "Post": {
+      "fields": {
+        "body": {
+          "type": "String",
+          "required": true
+        },
+        "id": {
+          "type": "Int",
+          "required": true
+        },
+        "title": {
+          "type": "String",
+          "required": true
+        },
+        "user": {
+          "type": "User",
+          "http": {
+            "path": "/users/{{value.userId}}"
+          }
+        },
+        "userId": {
+          "type": "Int",
+          "required": true
+        }
+      }
+    },
+    "Query": {
+      "fields": {
+        "posts": {
+          "type": "Post",
+          "list": true,
+          "http": {
+            "path": "/posts"
+          }
+        }
+      }
+    },
+    "User": {
+      "fields": {
+        "email": {
+          "type": "String",
+          "required": true
+        },
+        "id": {
+          "type": "Int",
+          "required": true
+        },
+        "name": {
+          "type": "String",
+          "required": true
+        },
+        "phone": {
+          "type": "String"
+        },
+        "username": {
+          "type": "String",
+          "required": true
+        },
+        "website": {
+          "type": "String"
+        }
+      }
+    }
+  }
+}
+```
+</TabItem>
+</Tabs>
 
 The above file is a standard `.graphQL` file, with a few additions such as `@upstream` and `@http` directives. So basically we specify the GraphQL schema and how to resolve that GraphQL schema in the same file, without having to write any code!

--- a/docs/getting_started/configuration.mdx
+++ b/docs/getting_started/configuration.mdx
@@ -8,10 +8,14 @@ import TabItem from '@theme/TabItem';
 For our first example, we are going to compose a GraphQL schema from the REST APIs at <a href="https://jsonplaceholder.typicode.com" target="_blank">https://jsonplaceholder.typicode.com</a>, a free online REST API with some fake data.
 We will use the API at `/users` to get a list of users, and `/users/:id/posts` to get the posts for each user, and compose them into a single GraphQL schema.
 
+We can use the following formats to define our GraphQL schema: `.graphql`, `.yml`, `.json`.
+
 Create one of the following files and paste the contents into it.
 
 <Tabs>
-<TabItem value="graphql" label="jsonplaceholder.graphql">
+<TabItem value="graphql" label="graphql">
+
+`jsonplaceholder.graphql`
 
 ```graphql showLineNumbers
 schema
@@ -48,7 +52,9 @@ type Post {
 ```
 
 </TabItem>
-<TabItem value="yml" label="jsonplaceholder.yml">
+<TabItem value="yml" label="yml">
+
+`jsonplaceholder.yml`
 
 ```yml showLineNumbers 
 server:
@@ -108,7 +114,9 @@ types:
 ```
 
 </TabItem>
-<TabItem value="json" label="jsonplaceholder.json">
+<TabItem value="json" label="json">
+
+`jsonplaceholder.json`
 
 ```json showLineNumbers
 {

--- a/docs/getting_started/launch.mdx
+++ b/docs/getting_started/launch.mdx
@@ -2,12 +2,34 @@
 title: Launch
 sidebar_position: 3
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
-Now, run the following command to start the server with the full path to the `jsonplaceholder.graphql` file that you created above.
+Now, run the following command to start the server with the full path to the file that you created earlier.
+
+<Tabs>
+<TabItem value="graphql" label="graphql">
 
 ```bash
 tailcall start ./jsonplaceholder.graphql
 ```
+
+</TabItem>
+<TabItem value="yml" label="yml">
+
+```bash
+tailcall start ./jsonplaceholder.yml
+```
+
+</TabItem>
+<TabItem value="json" label="json">
+
+```bash
+tailcall start ./jsonplaceholder.json
+```
+
+</TabItem>
+</Tabs>
 
 If the command succeeds, you should see logs like the following below.
 


### PR DESCRIPTION
Added in two places in the getting started guide, probably worth adding to the regular guides too.

<img width="660" alt="image" src="https://github.com/tailcallhq/tailcallhq.github.io/assets/12949385/5bafeb3f-7456-409f-aedf-a8a433751923">

<img width="664" alt="image" src="https://github.com/tailcallhq/tailcallhq.github.io/assets/12949385/58d69752-adb5-42fc-9c4a-6447c9d080fa">
