### PR TITLE
perf: replaced lottie-react with lottie-light-react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "docusaurus-lunr-search": "^3.3.2",
         "graphiql": "^3.2.0",
         "graphql-ws": "^5.16.0",
-        "lottie-react": "^2.4.0",
+        "lottie-light-react": "^2.4.0",
         "postcss": "^8.4.33",
         "prism-react-renderer": "^2.3.1",
         "react": "^18.2.0",
@@ -12718,10 +12718,10 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/lottie-react": {
+    "node_modules/lottie-light-react": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/lottie-react/-/lottie-react-2.4.0.tgz",
-      "integrity": "sha512-pDJGj+AQlnlyHvOHFK7vLdsDcvbuqvwPZdMlJ360wrzGFurXeKPr8SiRCjLf3LrNYKANQtSsh5dz9UYQHuqx4w==",
+      "resolved": "https://registry.npmjs.org/lottie-light-react/-/lottie-light-react-2.4.0.tgz",
+      "integrity": "sha512-TXJOnyqEc6ev9/um8Xkxve5EVcgCX2pi1olWc8jj+81qaPyFBA+VxHIc2Ojl42IqeAiKhGHz098ztQOIImJcyg==",
       "dependencies": {
         "lottie-web": "^5.10.2"
       },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "docusaurus-lunr-search": "^3.3.2",
     "graphiql": "^3.2.0",
     "graphql-ws": "^5.16.0",
-    "lottie-react": "^2.4.0",
+    "lottie-light-react": "^2.4.0",
     "postcss": "^8.4.33",
     "prism-react-renderer": "^2.3.1",
     "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
+    "analyze": "docusaurus build --bundle-analyzer",
     "format:fix": "prettier --write '**/*.{graphql,yml,json,md,sh,ts,tsx,js}'",
     "format:check": "prettier --check '**/*.{graphql,yml,json,md,sh,ts,tsx,js}'",
     "write-translations": "docusaurus write-translations",

--- a/src/components/home/GraphContainer.tsx
+++ b/src/components/home/GraphContainer.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useRef} from "react"
 import CountUp from "react-countup"
 import TrackVisibility from "react-on-screen"
-import {InteractivityProps, LottieRefCurrentProps, useLottie, useLottieInteractivity} from "lottie-react"
+import {InteractivityProps, LottieRefCurrentProps} from "lottie-light-react"
 import LottieContainer from "./LottieContainer.tsxsrc/components/home/LottieContainer"
 
 type GraphContainerProps = {

--- a/src/components/home/LegacyGateway.tsx
+++ b/src/components/home/LegacyGateway.tsx
@@ -1,7 +1,6 @@
 import React from "react"
 import Heading from "@theme/Heading"
 
-import {useLottie} from "lottie-react"
 import SolutionGraphic from "@site/static/animations/solution-graphic.json"
 import SectionTitle from "../shared/SectionTitle"
 import LottieContainer from "./LottieContainer.tsxsrc/components/home/LottieContainer"

--- a/src/components/home/LottieContainer.tsxsrc/components/home/LottieContainer.tsx
+++ b/src/components/home/LottieContainer.tsxsrc/components/home/LottieContainer.tsx
@@ -1,14 +1,14 @@
 import React, {useEffect, useState} from "react"
 import BrowserOnly from "@docusaurus/BrowserOnly"
 import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment"
-import type {LottieComponentProps} from "lottie-react"
+import type {LottieComponentProps} from "lottie-light-react"
 
 const LottieContainer: React.FC<LottieComponentProps> = ({animationData, loop = true, className = ""}) => {
   const [Lottie, setLottie] = useState<{default: React.FC<LottieComponentProps>} | null>(null)
 
   useEffect(() => {
     if (ExecutionEnvironment.canUseDOM) {
-      import("lottie-react").then((LottieModule) => {
+      import("lottie-light-react").then((LottieModule) => {
         setLottie(LottieModule)
       })
     }


### PR DESCRIPTION
This PR replaces lottie-react library with lottie-light-react aiming to reduce js bundle size.

Results :

Stat bundle size - 6.03 MB to **5.81 MB**
Parsed bundle size - 3.33 MB to **3.2 MB**
Gzipped bundle size - 1.17 MB to **1.14 MB**

**Before:**

https://github.com/tailcallhq/tailcallhq.github.io/assets/64700961/325ea164-8568-4f78-b2b4-2843e81f6ab7



**After:**

https://github.com/tailcallhq/tailcallhq.github.io/assets/64700961/a9572978-d13c-4f40-a293-512a912aa834


