### PR TITLE
Feat: Adding docs in sitemap and minor improvements.

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -69,9 +69,10 @@ export default {
           customCss: require.resolve("./src/css/custom.css"),
         },
         sitemap: {
+          lastmod: "date",
           changefreq: "weekly",
-          priority: 0.5,
-          ignorePatterns: ["/blog/**", "/docs/**"],
+          priority: 0.7,
+          ignorePatterns: ["/blog/**"],
         },
       },
     ],


### PR DESCRIPTION
/claim #277 
closes #277 


1. Adding info of docs in sitemap 
2. adding `lastmod` date field in SEO
3. increased the priority

Ref: https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-sitemap
