### PR TITLE
ci: fix hashnode use `tj-actions/changed-files`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,23 +42,20 @@ jobs:
         with:
           folder: build
 
-      - name: Get changed files
-        id: changes
-        run: |
-          echo "files<<EOF" >> $GITHUB_ENV
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep '^blog/' || true
-          else
-            git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '^blog/' || true
-          fi >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+      - name: Get changed markdown files
+        id: changed-markdown-files
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+            blog/**.md
 
       - name: Publish to Hashnode 📝
-        if: github.ref == 'refs/heads/develop' && env.files != ''
+        if: github.ref == 'refs/heads/develop' && steps.changed-markdown-files.outputs.any_changed == 'true'
         env:
           HASHNODE_PAT: ${{ secrets.HASHNODE_PAT }}
           HASHNODE_PUBLICATION_ID: ${{ secrets.HASHNODE_PUBLICATION_ID }}
+          CHANGED_FILES: ${{ steps.changed-markdown-files.outputs.all_changed_files }}
         run: |
           cd ./publish-hashnode 
           npm run generate
-          npx --yes tsx ./src/index.ts "${{ env.files }}"
+          npx --yes tsx ./src/index.ts "$CHANGED_FILES"

--- a/publish-hashnode/src/index.ts
+++ b/publish-hashnode/src/index.ts
@@ -4,7 +4,7 @@ import {addBaseUrlToImages, extractFrontMatterAndContent} from "./utils/markdown
 import {HASHNODE_PUBLICATION_ID} from "./utils/constants"
 
 const main = async () => {
-  const changedFiles = process.argv[2].split("\n")
+  const changedFiles = process.argv[2].split(" ")
   for (const file of changedFiles) {
     if (file.startsWith("blog/")) {
       try {


### PR DESCRIPTION
Fixes CI for hashnode by replacing current script with https://github.com/tj-actions/changed-files

Tested with single file, multi files.