### PR TITLE
Update documentation with the updated logic for batchKey and query field

### DIFF
--- a/docs/N+1.md
+++ b/docs/N+1.md
@@ -315,7 +315,7 @@ The described changes introduce two significant tweaks to the `@http` directive:
        )
    }
    ```
-   This parameter instructs the system to use the user's `id`, in the `User` type, as the unique identifier. This helps in differentiating between users received from the batch API.
+   This parameter instructs the system to use the user's `id`, in the `User` type, as the unique identifier. This helps in differentiating between users received from the batch API. When `batchKey` is present, Tailcall considers the first `query` parameter to be the batch query parameter, so remember to adjust the order of the items accordingly.
 
 Let's see what the server logs when you now start Tailcall with the updated configuration:
 

--- a/docs/directives.md
+++ b/docs/directives.md
@@ -882,7 +882,7 @@ type Mutation {
 
 ### query
 
-Represents the API call's query parameters, either as a static object or with dynamic parameters using Mustache templates. These parameters append to the URL.
+Represents the API call's query parameters, either as a static object or with dynamic parameters using Mustache templates. These parameters append to the URL. Keep in mind that when `batchKey` is present, Tailcall considers the first `query` parameter to be the batch query parameter, so remember to adjust the order of the items accordingly.
 
 ```graphql showLineNumbers
 type Query {
@@ -950,7 +950,7 @@ In this scenario, the `User-Name` header's value will dynamically adjust accordi
 
 ### batchKey
 
-Groups data requests into a single call, enhancing efficiency. Refer to our [n + 1 guide](./N+1.md) for more details.
+Groups data requests into a single call, enhancing efficiency. Refer to our [n + 1 guide](./N+1.md) for more details. When `batchKey` is present, Tailcall considers the first `query` parameter to be the batch query parameter, so remember to adjust the order of the items accordingly.
 
 ```graphql showLineNumbers
 type Post {


### PR DESCRIPTION
Based on the changes to https://github.com/tailcallhq/tailcall/pull/2495, I updated the documentation. I scanned the documentation to find all the points where the `batchKey` and `query` fields are used.