### PR TITLE
fix: search ui

### DIFF
--- a/src/theme/SearchBar/styles.css
+++ b/src/theme/SearchBar/styles.css
@@ -105,7 +105,7 @@
   box-shadow: none;
 }
 
-@media only screen and (max-width: 1000px) {
+@media only screen and (max-width: 996px) {
   .DocSearch-Button {
     width: fit-content;
     border: none;
@@ -156,7 +156,11 @@
   color: #858586;
 }
 
-@media only screen and (min-width: 769px) {
+.DocSearch-Button-Placeholder {
+  display: none;
+}
+
+@media only screen and (min-width: 996px) {
   .DocSearch-Button {
     padding-top: 1.3rem;
     padding-bottom: 1.3rem;
@@ -165,6 +169,9 @@
     margin-top: 1.3rem;
     margin-bottom: 1.3rem;
     border: 1px solid var(--ifm-color-gray-800);
+  }
+  .DocSearch-Button-Placeholder {
+    display: block;
   }
 }
 

--- a/src/theme/SearchBar/styles.css
+++ b/src/theme/SearchBar/styles.css
@@ -141,3 +141,33 @@
     border: 1px solid var(--ifm-color-brand-light-600);
   }
 }
+
+.DocSearch-Button-Key {
+  border: 1px solid #858586;
+  background: transparent;
+  box-shadow: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  padding: 0;
+  color: #858586;
+}
+
+@media only screen and (min-width: 769px) {
+  .DocSearch-Button {
+    padding-top: 1.3rem;
+    padding-bottom: 1.3rem;
+    padding-left: 0.6rem;
+    padding-right: 0.6rem;
+    margin-top: 1.3rem;
+    margin-bottom: 1.3rem;
+    border: 1px solid var(--ifm-color-gray-800);
+  }
+}
+
+.DocSearch-Button-Keys kbd.DocSearch-Button-Key:first-child {
+  font-size: 16px;
+}


### PR DESCRIPTION
Fixes search UI to match the previous design

Before:

<img width="317" alt="image" src="https://github.com/user-attachments/assets/969fa933-dea2-416e-b071-751e24abdc7d">

After:

<img width="314" alt="image" src="https://github.com/user-attachments/assets/c96bb57d-a8a8-4f24-add7-9f9f5f8e0e44">
