### PR TITLE
fix(506): 404 error & images not loading

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -257,12 +257,18 @@ export default {
         sidebarPath: require.resolve("./graphql/sidebar.ts"),
       },
     ],
-    [
-      "@docusaurus/plugin-ideal-image",
-      {
-        highlightResult: true,
-      },
-    ],
+    // [
+    // "@docusaurus/plugin-ideal-image",
+    // {
+    //   {
+    //     // quality: 70,
+    //     // max: 1030, // max resized image's size.
+    //     // min: 640, // min resized image's size. if original is lower, use that size.
+    //     // steps: 2, // the max number of images generated between min and max (inclusive)
+    //     disableInDev: false,
+    //   },
+    // },
+    // ],
     // causing problem in layouts and image loads
     async function myPlugin() {
       return {

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -257,19 +257,6 @@ export default {
         sidebarPath: require.resolve("./graphql/sidebar.ts"),
       },
     ],
-    // [
-    // "@docusaurus/plugin-ideal-image",
-    // {
-    //   {
-    //     // quality: 70,
-    //     // max: 1030, // max resized image's size.
-    //     // min: 640, // min resized image's size. if original is lower, use that size.
-    //     // steps: 2, // the max number of images generated between min and max (inclusive)
-    //     disableInDev: false,
-    //   },
-    // },
-    // ],
-    // causing problem in layouts and image loads
     async function myPlugin() {
       return {
         name: "docusaurus-tailwindcss",


### PR DESCRIPTION
Fixes: #506
/claim #506
This issue was caused due to irrelevant changes in #499. I've reverted it back.
<img width="917" alt="Screenshot 2024-09-25 at 10 09 25 AM" src="https://github.com/user-attachments/assets/2f7760b3-ccfa-45e9-a552-3a7e4d48b8fc">
Also, `@docusaurus/plugin-ideal-image` doesn't have `highlightResult`.