### PR TITLE
refactor: place dedupe argument on the correct directives

### DIFF
--- a/docs/directives.md
+++ b/docs/directives.md
@@ -1754,17 +1754,6 @@ schema @server(
 Batching can improve performance but may introduce latency if one request in the batch takes longer. It also makes network traffic debugging harder.
 :::
 
-### dedupe
-
-A boolean flag, if set to `true`, will enable deduplication of IO operations to enhance performance. This flag prevents duplicate IO requests from being executed concurrently, reducing resource load. If not specified, this feature defaults to `false`.
-
-```graphql showLineNumbers
-schema @server(
-  port: 8000
-  dedupe: true
-)
-```
-
 ### routes
 
 This optional field allows you to customize the server's endpoint paths, enabling you to override the default values for the GraphQL and status endpoints. If not specified, the following default paths will be used:

--- a/docs/directives.md
+++ b/docs/directives.md
@@ -686,6 +686,17 @@ type Query {
 }
 ```
 
+### dedupe
+
+A boolean flag, if set to `true`, will enable deduplication of IO operations to enhance performance. This flag prevents duplicate IO requests from being executed concurrently, reducing resource load. If not specified, this feature defaults to `false`.
+
+```graphql showLineNumbers
+@graphQL(
+  name: "users",
+  dedupe: true
+)
+```
+
 Make sure you have also specified batch settings to the `@upstream` and to the `@graphQL` directive.
 
 ## @grpc Directive
@@ -868,6 +879,17 @@ type Query {
       }
     )
 }
+```
+
+### dedupe
+
+A boolean flag, if set to `true`, will enable deduplication of IO operations to enhance performance. This flag prevents duplicate IO requests from being executed concurrently, reducing resource load. If not specified, this feature defaults to `false`.
+
+```graphql showLineNumbers
+@grpc(
+  method: "news.UsersService.GetUserDetails"
+  dedupe: true
+)
 ```
 
 ## @http Directive
@@ -1094,6 +1116,17 @@ type Query {
       }
     )
 }
+```
+
+### dedupe
+
+A boolean flag, if set to `true`, will enable deduplication of IO operations to enhance performance. This flag prevents duplicate IO requests from being executed concurrently, reducing resource load. If not specified, this feature defaults to `false`.
+
+```graphql showLineNumbers
+@http(
+  path: "/users/"
+  dedupe: true
+)
 ```
 
 ## @js Directive


### PR DESCRIPTION
According to this file https://github.com/tailcallhq/tailcall/blob/main/generated/.tailcallrc.graphql `dedupe` is not present on `@server` but its available on `@http`, `@grpc` and `graphql` directives