### PR TITLE
fix: broken link in docs

### DIFF
--- a/docs/data-dog.md
+++ b/docs/data-dog.md
@@ -23,7 +23,7 @@ This guide is based on the [official doc](https://docs.datadoghq.com/getting_sta
 
 3. **Set Up OpenTelemetry Collector:**
 
-- Integration with Datadog requires an [OpenTelemetry Collector](#opentelemetry-collector) to send data. Below is a sample configuration file:
+- Integration with Datadog requires an [OpenTelemetry Collector](https://docs.datadoghq.com/opentelemetry/collector_exporter/otel_collector_datadog_exporter/?tab=onahost) to send data. Below is a sample configuration file:
 
   ```yml
   receivers:

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -37,7 +37,8 @@ export default {
   url: "https://tailcall.run",
   baseUrl: "/",
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "warn",
+  onBrokenMarkdownLinks: "throw",
+  onBrokenAnchors: "throw",
   favicon: "images/favicon.ico",
 
   // GitHub pages deployment config.


### PR DESCRIPTION
Changes included:

- Enforce build to fail if we have any broken links in docs
- Fixed datadog otel collector broken link