### PR TITLE
perf: defer homepage third-party embeds

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -16,15 +16,6 @@ export default {
     {
       tagName: "script",
       attributes: {
-        id: "chatbotscript",
-        "data-accountid": "CZPG9aVdtk59Tjz4SMTu8w==",
-        "data-websiteid": "75VGI0NlBqessD4BQn2pFg==",
-        src: "https://app.robofy.ai/bot/js/common.js?v=" + new Date().getTime(),
-      },
-    },
-    {
-      tagName: "script",
-      attributes: {
         type: "application/ld+json",
       },
       innerHTML: JSON.stringify({

--- a/src/components/home/IntroductionVideo/index.tsx
+++ b/src/components/home/IntroductionVideo/index.tsx
@@ -1,10 +1,11 @@
-import React, {useRef} from "react"
+import React, {useRef, useState} from "react"
 import {useCookieConsent} from "@site/src/utils/hooks/useCookieConsent"
 import "./style.css"
 
 const IntroductionVideo: React.FC = () => {
   const videoId = "1011521201"
   const videoRef = useRef<HTMLDivElement>(null)
+  const [isPlaying, setIsPlaying] = useState(false)
   const {getCookieConsent} = useCookieConsent()
   const cookieConsent = getCookieConsent()
 
@@ -15,14 +16,25 @@ const IntroductionVideo: React.FC = () => {
   return (
     <div className="video-wrapper" ref={videoRef}>
       <div className="video-container">
-        <iframe
-          src={`https://player.vimeo.com/video/${videoId}?autoplay=0&badge=0&autopause=0&player_id=0&app_id=58479${handleVimeoAnalytics()}`}
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-          allowFullScreen
-          className="absolute top-0 left-0 w-full h-full"
-          title="Tailcall Introduction Video"
-          loading="lazy"
-        />
+        {isPlaying ? (
+          <iframe
+            src={`https://player.vimeo.com/video/${videoId}?autoplay=1&badge=0&autopause=0&player_id=0&app_id=58479${handleVimeoAnalytics()}`}
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+            className="absolute top-0 left-0 w-full h-full"
+            title="Tailcall Introduction Video"
+            loading="lazy"
+          />
+        ) : (
+          <button
+            className="video-placeholder"
+            type="button"
+            aria-label="Play Tailcall introduction video"
+            onClick={() => setIsPlaying(true)}
+          >
+            <span className="video-play-button" aria-hidden="true" />
+          </button>
+        )}
       </div>
     </div>
   )

--- a/src/components/home/IntroductionVideo/style.css
+++ b/src/components/home/IntroductionVideo/style.css
@@ -33,6 +33,48 @@
   background-size: 100%;
 }
 
+.video-placeholder {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  cursor: pointer;
+  background: transparent;
+}
+
+.video-play-button {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  display: flex;
+  width: 4rem;
+  height: 4rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  background: rgba(0, 0, 0, 0.72);
+  transform: translate(-50%, -50%);
+  transition:
+    transform 160ms ease,
+    background-color 160ms ease;
+}
+
+.video-play-button::before {
+  content: "";
+  display: block;
+  margin-left: 0.25rem;
+  border-top: 0.75rem solid transparent;
+  border-bottom: 0.75rem solid transparent;
+  border-left: 1.125rem solid #fff;
+}
+
+.video-placeholder:hover .video-play-button,
+.video-placeholder:focus-visible .video-play-button {
+  background: rgba(0, 0, 0, 0.86);
+  transform: translate(-50%, -50%) scale(1.06);
+}
+
 .video-background {
   position: absolute;
   top: 0;

--- a/src/components/shared/GlobalLayout.tsx
+++ b/src/components/shared/GlobalLayout.tsx
@@ -23,6 +23,32 @@ const GlobalLayout: React.FC = () => {
     }
   }, [cookieConsent])
 
+  useEffect(() => {
+    if (typeof window === "undefined" || document.getElementById("chatbotscript")) return
+
+    const loadChatbot = () => {
+      const script = document.createElement("script")
+
+      script.id = "chatbotscript"
+      script.dataset.accountid = "CZPG9aVdtk59Tjz4SMTu8w=="
+      script.dataset.websiteid = "75VGI0NlBqessD4BQn2pFg=="
+      script.src = "https://app.robofy.ai/bot/js/common.js"
+      script.async = true
+
+      document.body.appendChild(script)
+    }
+
+    const idleWindow = window as Window & {
+      requestIdleCallback?: (callback: () => void) => number
+    }
+
+    if (idleWindow.requestIdleCallback) {
+      idleWindow.requestIdleCallback(loadChatbot)
+    } else {
+      window.setTimeout(loadChatbot, 1500)
+    }
+  }, [])
+
   return (
     <>
       <CookieConsentModal

--- a/src/components/shared/GlobalLayout.tsx
+++ b/src/components/shared/GlobalLayout.tsx
@@ -24,7 +24,7 @@ const GlobalLayout: React.FC = () => {
   }, [cookieConsent])
 
   useEffect(() => {
-    if (typeof window === "undefined" || document.getElementById("chatbotscript")) return
+    if (typeof window === "undefined" || !cookieConsent?.accepted || document.getElementById("chatbotscript")) return
 
     const loadChatbot = () => {
       const script = document.createElement("script")
@@ -47,7 +47,7 @@ const GlobalLayout: React.FC = () => {
     } else {
       window.setTimeout(loadChatbot, 1500)
     }
-  }, [])
+  }, [cookieConsent?.accepted])
 
   return (
     <>


### PR DESCRIPTION
/claim #217

## Summary

This PR targets the mobile Lighthouse performance bounty for `/` by reducing third-party work on the initial homepage load.

- Moves the Robofy chatbot script out of `headTags` and injects it after the page becomes idle.
- Replaces the eager Vimeo iframe with a click-to-play poster button so Lighthouse does not load the Vimeo player during the initial page audit.
- Preserves the existing cookie consent / Vimeo DNT behavior when the user plays the video.

## Verification

- `npm ci`
- `npm run build`
- `npx prettier --check docusaurus.config.ts src/components/shared/GlobalLayout.tsx src/components/home/IntroductionVideo/index.tsx src/components/home/IntroductionVideo/style.css`
- `git diff --check`
- Confirmed `build/index.html` no longer directly contains `player.vimeo.com`, `chatbotscript`, or `app.robofy.ai`.

## Note

`npm run typecheck` was also attempted, but it still fails on existing unrelated repository issues outside this change:

- `publish-externals/src/utils/hashnode.ts` missing `../../generated/graphql`
- `src/components/playground/Playground.tsx` GraphiQL fetcher type mismatch
- `src/theme/SearchBar` / `src/theme/SearchPage` DocSearch and Algolia type errors
