### PR TITLE
feat: Add configuration generator UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,9 @@
         "@docusaurus/theme-search-algolia": "3.6.3",
         "@graphiql/create-fetcher": "^0.1.0",
         "@mdx-js/react": "^3.0.1",
+        "@rjsf/core": "^6.5.3",
+        "@rjsf/utils": "^6.5.3",
+        "@rjsf/validator-ajv8": "^6.5.3",
         "autoprefixer": "^10.4.19",
         "clsx": "^2.1.1",
         "graphiql": "^3.3.1",
@@ -6902,6 +6905,110 @@
       "integrity": "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==",
       "dev": true
     },
+    "node_modules/@rjsf/core": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-6.5.3.tgz",
+      "integrity": "sha512-S9v7EcqCvcC9buGmlThe/hd6PK9TIyzOF8E9EstbWPXkQtEWGP0heC1BloQTEiXBsAwpR5NDVbhIau2GYPbiKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash": "^4.18.1",
+        "lodash-es": "^4.18.1",
+        "markdown-to-jsx": "^8.0.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@rjsf/utils": "^6.5.x",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@rjsf/core/node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/@rjsf/utils": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@rjsf/utils/-/utils-6.5.3.tgz",
+      "integrity": "sha512-lrGxVR26xjCjea8OqIDpSXH1FDAfhCON6DHja/PhzJBLJjs45+sdilmJA78c+tL4oN5Jpj2dTOoFMAZ7bIhRvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@x0k/json-schema-merge": "^1.0.3",
+        "fast-equals": "^6.0.0",
+        "fast-uri": "^3.1.2",
+        "jsonpointer": "^5.0.1",
+        "lodash": "^4.18.1",
+        "lodash-es": "^4.18.1",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@rjsf/utils/node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/@rjsf/utils/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/@rjsf/validator-ajv8": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@rjsf/validator-ajv8/-/validator-ajv8-6.5.3.tgz",
+      "integrity": "sha512-CdaoNIbG+fbj9S9ezex16/Eka5KbsPfpUDgthVedS1rQ/mXd4VhvnvLQopYpIAymYrIWrCVDCanN/kB8wP3OYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.18.0",
+        "ajv-formats": "^2.1.1",
+        "lodash": "^4.18.1",
+        "lodash-es": "^4.18.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@rjsf/utils": "^6.5.x"
+      }
+    },
+    "node_modules/@rjsf/validator-ajv8/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@rjsf/validator-ajv8/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@rjsf/validator-ajv8/node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/@rspack/binding": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.1.3.tgz",
@@ -8714,6 +8821,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@x0k/json-schema-merge": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@x0k/json-schema-merge/-/json-schema-merge-1.0.3.tgz",
+      "integrity": "sha512-lerJC4sI9CNUQWdff3PnU1YJOqazD6TjMcvxZIPXUBjn4j1cUiXE0LvzhMnGYzKKr271TkvXJtH7gEwksrtn+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -12616,6 +12732,15 @@
       "version": "3.1.3",
       "license": "MIT"
     },
+    "node_modules/fast-equals": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-6.0.0.tgz",
+      "integrity": "sha512-PFhhIGgdM79r5Uztdj9Zb6Tt1zKafqVfdMGwVca1z5z6fbX7DmsySSuJd8HiP6I1j505DCS83cLxo5rmSNeVEA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "license": "MIT"
@@ -12651,6 +12776,22 @@
       "dependencies": {
         "fast-decode-uri-component": "^1.0.1"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-url-parser": {
       "version": "1.1.3",
@@ -15206,6 +15347,15 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/jsprim": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
@@ -15679,6 +15829,12 @@
       "version": "4.17.21",
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "license": "MIT"
@@ -15922,6 +16078,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/markdown-to-jsx": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-8.0.0.tgz",
+      "integrity": "sha512-hWEaRxeCDjes1CVUQqU+Ov0mCqBqkGhLKjL98KdbwHSgEWZZSJQeGlJQatVfeZ3RaxrfTrZZ3eczl2dhp5c/pA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/mdast-util-directive": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,11 @@
     "@docusaurus/plugin-ideal-image": "3.6.3",
     "@docusaurus/preset-classic": "3.6.3",
     "@docusaurus/theme-search-algolia": "3.6.3",
+    "@graphiql/create-fetcher": "^0.1.0",
     "@mdx-js/react": "^3.0.1",
+    "@rjsf/core": "^6.5.3",
+    "@rjsf/utils": "^6.5.3",
+    "@rjsf/validator-ajv8": "^6.5.3",
     "autoprefixer": "^10.4.19",
     "clsx": "^2.1.1",
     "graphiql": "^3.3.1",
@@ -49,8 +53,7 @@
     "react-hot-toast": "^2.4.1",
     "react-on-screen": "^2.1.1",
     "react-platform-js": "^0.0.1",
-    "tailwindcss": "^3.4.4",
-    "@graphiql/create-fetcher": "^0.1.0"
+    "tailwindcss": "^3.4.4"
   },
   "devDependencies": {
     "@babel/core": "^7.24.7",

--- a/src/pages/app/config.tsx
+++ b/src/pages/app/config.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+import Layout from '@theme/Layout';
+import Form from '@rjsf/core';
+import validator from '@rjsf/validator-ajv8';
+
+export default function ConfigApp() {
+  const [schema, setSchema] = useState<any>(null);
+  const [formData, setFormData] = useState<any>({});
+  
+  useEffect(() => {
+    fetch('https://raw.githubusercontent.com/tailcallhq/tailcall/main/generated/.tailcallrc.schema.json')
+      .then((res) => res.json())
+      .then((data) => {
+        setSchema(data);
+      })
+      .catch((err) => console.error("Failed to load schema:", err));
+  }, []);
+
+  const handleDownload = () => {
+    const dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(formData, null, 2));
+    const downloadAnchorNode = document.createElement('a');
+    downloadAnchorNode.setAttribute("href",     dataStr);
+    downloadAnchorNode.setAttribute("download", ".tailcallrc.json");
+    document.body.appendChild(downloadAnchorNode);
+    downloadAnchorNode.click();
+    downloadAnchorNode.remove();
+  };
+
+  return (
+    <Layout
+      title="Tailcall Configurator"
+      description="Create, update, and download Tailcall Configurations visually"
+    >
+      <main className="container margin-vert--lg">
+        <div className="row">
+          <div className="col col--8 col--offset-2">
+            <h1>Tailcall Configurator</h1>
+            <p>Use the form below to visually generate your Tailcall configuration.</p>
+            
+            {schema ? (
+              <div className="card shadow--md padding--md" style={{ background: 'var(--ifm-background-surface-color)' }}>
+                <Form 
+                  schema={schema} 
+                  validator={validator}
+                  formData={formData}
+                  onChange={(e) => setFormData(e.formData)}
+                  onSubmit={handleDownload}
+                >
+                  <div style={{ marginTop: '20px' }}>
+                    <button type="submit" className="button button--primary button--lg">
+                      Download Configuration
+                    </button>
+                  </div>
+                </Form>
+              </div>
+            ) : (
+              <div className="text--center padding--xl">
+                <div>Loading schema...</div>
+              </div>
+            )}
+          </div>
+        </div>
+      </main>
+    </Layout>
+  );
+}


### PR DESCRIPTION
Closes #373 

Implemented a dynamic configuration generator utilizing `@rjsf/core` to parse the provided JSON schema from tailcallhq/tailcall into an interactive web form. 
Integrated straight into `/app/config` per requirements.

/claim #373