### PR TITLE
perf: reduce homepage render blocking work

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -20,6 +20,8 @@ export default {
         "data-accountid": "CZPG9aVdtk59Tjz4SMTu8w==",
         "data-websiteid": "75VGI0NlBqessD4BQn2pFg==",
         src: "https://app.robofy.ai/bot/js/common.js?v=" + new Date().getTime(),
+        async: "true",
+        defer: "true",
       },
     },
     {

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -14,6 +14,30 @@ export default {
   tagline: "GraphQL platform engineered for scale",
   headTags: [
     {
+      tagName: "link",
+      attributes: {
+        rel: "preconnect",
+        href: "https://fonts.googleapis.com",
+      },
+    },
+    {
+      tagName: "link",
+      attributes: {
+        rel: "preconnect",
+        href: "https://fonts.gstatic.com",
+        crossorigin: "anonymous",
+      },
+    },
+    {
+      tagName: "link",
+      attributes: {
+        rel: "preload",
+        as: "style",
+        href: "https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=Space+Mono&display=swap",
+        onload: "this.onload=null;this.rel='stylesheet'",
+      },
+    },
+    {
       tagName: "script",
       attributes: {
         id: "chatbotscript",

--- a/src/components/home/Banner.tsx
+++ b/src/components/home/Banner.tsx
@@ -2,7 +2,6 @@ import React from "react"
 import Heading from "@theme/Heading"
 
 import LinkButton from "../shared/LinkButton"
-import HeroImage from "@site/static/images/home/hero.svg"
 import {analyticsHandler} from "@site/src/utils"
 import {Theme, codeSandboxUrl} from "@site/src/constants"
 import {pageLinks} from "@site/src/constants/routes"
@@ -59,7 +58,13 @@ const Banner = (): JSX.Element => {
           </div>
         </div>
       </Section>
-      <HeroImage className="object-contain h-full sm:h-full w-full mt-8 max-w-7xl" />
+      <img
+        src="/images/home/hero.svg"
+        alt="Tailcall GraphQL platform workflow"
+        className="object-contain h-full sm:h-full w-full mt-8 max-w-7xl"
+        width={1400}
+        height={672}
+      />
     </main>
   )
 }

--- a/src/components/home/LazyHomeSection.tsx
+++ b/src/components/home/LazyHomeSection.tsx
@@ -1,0 +1,44 @@
+import React, {useEffect, useRef, useState} from "react"
+
+interface LazyHomeSectionProps {
+  children: React.ReactNode
+  minHeight?: number
+}
+
+const LazyHomeSection: React.FC<LazyHomeSectionProps> = ({children, minHeight = 320}) => {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container || isVisible) {
+      return
+    }
+
+    if (!("IntersectionObserver" in window)) {
+      setIsVisible(true)
+      return
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.disconnect()
+        }
+      },
+      {rootMargin: "600px 0px"}
+    )
+
+    observer.observe(container)
+    return () => observer.disconnect()
+  }, [isVisible])
+
+  return (
+    <div ref={containerRef} style={isVisible ? undefined : {minHeight}}>
+      {isVisible ? children : null}
+    </div>
+  )
+}
+
+export default LazyHomeSection

--- a/src/components/home/index.tsx
+++ b/src/components/home/index.tsx
@@ -8,17 +8,28 @@ import Configuration from "./Configuration"
 import Testimonials from "./Testimonials"
 import Announcement from "../shared/Announcement"
 import IntroductionVideo from "./IntroductionVideo"
+import LazyHomeSection from "./LazyHomeSection"
 const HomePage = (): JSX.Element => {
   return (
     <div className="">
       <Banner />
       <Configuration />
-      <IntroductionVideo />
-      <Testimonials />
-      <Benefits />
-      <Graph />
+      <LazyHomeSection minHeight={360}>
+        <IntroductionVideo />
+      </LazyHomeSection>
+      <LazyHomeSection minHeight={520}>
+        <Testimonials />
+      </LazyHomeSection>
+      <LazyHomeSection minHeight={520}>
+        <Benefits />
+      </LazyHomeSection>
+      <LazyHomeSection minHeight={680}>
+        <Graph />
+      </LazyHomeSection>
       {/* <Playground /> */}
-      <Discover />
+      <LazyHomeSection minHeight={208}>
+        <Discover />
+      </LazyHomeSection>
     </div>
   )
 }

--- a/src/components/home/index.tsx
+++ b/src/components/home/index.tsx
@@ -13,7 +13,9 @@ const HomePage = (): JSX.Element => {
   return (
     <div className="">
       <Banner />
-      <Configuration />
+      <LazyHomeSection minHeight={560}>
+        <Configuration />
+      </LazyHomeSection>
       <LazyHomeSection minHeight={360}>
         <IntroductionVideo />
       </LazyHomeSection>

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,5 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=Space+Mono&display=swap");
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
## Summary
- Render the large homepage hero SVG as an external static image instead of inlining it into the initial document.
- Move Google Fonts out of the blocking CSS import path and preload the stylesheet with `font-display=swap`.
- Mark the Robofy chatbot script as async/deferred.
- Lazy-render below-the-fold homepage sections so `/` starts with much less DOM and less initial render work.

/claim #217

## Verification
- `npm run build`: passes
- `git diff --check`: clean
- Local Lighthouse before the optimization pass, mobile `/`: Performance 52, FCP 14.1s, Speed Index 14.1s, TBT 210ms, document transfer about 336 KB, DOM 3,609 elements.
- Local Lighthouse after the optimization pass, mobile `/`: Performance 66, FCP 3.6s, Speed Index 3.6s, TBT 100ms, DOM 510 elements.
- Local Lighthouse after the optimization pass, desktop `/`: Performance 87, Best Practices 100, FCP 0.7s, Speed Index 0.7s, TBT 0ms, DOM 473 elements.

## Notes
- `npm run typecheck` currently fails on existing unrelated generated GraphQL / GraphiQL fetcher / Algolia declaration errors outside this patch.
- This keeps the patch scoped to the homepage critical path rather than broad Docusaurus/CSS rewrites.