### PR TITLE
perf: defer chatbot script loading

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -19,6 +19,7 @@ export default {
         id: "chatbotscript",
         "data-accountid": "CZPG9aVdtk59Tjz4SMTu8w==",
         "data-websiteid": "75VGI0NlBqessD4BQn2pFg==",
+        defer: "true",
         src: "https://app.robofy.ai/bot/js/common.js?v=" + new Date().getTime(),
       },
     },


### PR DESCRIPTION
### Summary
- Defers the third-party Robofy chatbot script loaded through Docusaurus headTags.
- Keeps the existing script and data attributes intact while avoiding a blocking head script during initial parsing.

### Validation
- npm run build
- Verified build/index.html includes chatbotscript with defer="true".

Related to #217.