### PR TITLE
perf: lazy load homepage embeds

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -16,15 +16,6 @@ export default {
     {
       tagName: "script",
       attributes: {
-        id: "chatbotscript",
-        "data-accountid": "CZPG9aVdtk59Tjz4SMTu8w==",
-        "data-websiteid": "75VGI0NlBqessD4BQn2pFg==",
-        src: "https://app.robofy.ai/bot/js/common.js?v=" + new Date().getTime(),
-      },
-    },
-    {
-      tagName: "script",
-      attributes: {
         type: "application/ld+json",
       },
       innerHTML: JSON.stringify({

--- a/src/components/home/IntroductionVideo/index.tsx
+++ b/src/components/home/IntroductionVideo/index.tsx
@@ -1,10 +1,11 @@
-import React, {useRef} from "react"
+import React, {useRef, useState} from "react"
 import {useCookieConsent} from "@site/src/utils/hooks/useCookieConsent"
 import "./style.css"
 
 const IntroductionVideo: React.FC = () => {
   const videoId = "1011521201"
   const videoRef = useRef<HTMLDivElement>(null)
+  const [isVideoLoaded, setIsVideoLoaded] = useState(false)
   const {getCookieConsent} = useCookieConsent()
   const cookieConsent = getCookieConsent()
 
@@ -15,14 +16,25 @@ const IntroductionVideo: React.FC = () => {
   return (
     <div className="video-wrapper" ref={videoRef}>
       <div className="video-container">
-        <iframe
-          src={`https://player.vimeo.com/video/${videoId}?autoplay=0&badge=0&autopause=0&player_id=0&app_id=58479${handleVimeoAnalytics()}`}
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-          allowFullScreen
-          className="absolute top-0 left-0 w-full h-full"
-          title="Tailcall Introduction Video"
-          loading="lazy"
-        />
+        {isVideoLoaded ? (
+          <iframe
+            src={`https://player.vimeo.com/video/${videoId}?autoplay=1&badge=0&autopause=0&player_id=0&app_id=58479${handleVimeoAnalytics()}`}
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+            className="absolute top-0 left-0 w-full h-full"
+            title="Tailcall Introduction Video"
+            loading="lazy"
+          />
+        ) : (
+          <button
+            className="video-play-button"
+            type="button"
+            aria-label="Play Tailcall introduction video"
+            onClick={() => setIsVideoLoaded(true)}
+          >
+            <span aria-hidden="true" className="video-play-icon" />
+          </button>
+        )}
       </div>
     </div>
   )

--- a/src/components/home/IntroductionVideo/style.css
+++ b/src/components/home/IntroductionVideo/style.css
@@ -33,6 +33,53 @@
   background-size: 100%;
 }
 
+.video-play-button {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.video-play-button::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.18);
+  transition: background 160ms ease;
+}
+
+.video-play-button:hover::before,
+.video-play-button:focus-visible::before {
+  background: rgba(0, 0, 0, 0.28);
+}
+
+.video-play-icon {
+  position: relative;
+  z-index: 1;
+  width: 4.5rem;
+  height: 4.5rem;
+  border-radius: 9999px;
+  background: #ffe933;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.22);
+}
+
+.video-play-icon::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 52%;
+  transform: translate(-40%, -50%);
+  border-top: 1rem solid transparent;
+  border-bottom: 1rem solid transparent;
+  border-left: 1.45rem solid #111;
+}
+
 .video-background {
   position: absolute;
   top: 0;

--- a/src/components/shared/GlobalLayout.tsx
+++ b/src/components/shared/GlobalLayout.tsx
@@ -3,6 +3,7 @@ import {pageLinks} from "@site/src/constants/routes"
 import CookieConsentModal from "./CookieConsentModal/CookieConsentModal"
 import GlobalHead from "./GlobalHead"
 import {useCookieConsentManager} from "./CookieConsentProvider"
+import LazyChatbotScript from "./LazyChatbotScript"
 
 const GlobalLayout: React.FC = () => {
   const {
@@ -33,6 +34,7 @@ const GlobalLayout: React.FC = () => {
         onPartialAccept={onPartialAccept}
       />
       <GlobalHead isCookieConsentAccepted={Boolean(cookieConsent?.accepted)} preferences={cookieConsent?.preferences} />
+      <LazyChatbotScript />
     </>
   )
 }

--- a/src/components/shared/LazyChatbotScript.tsx
+++ b/src/components/shared/LazyChatbotScript.tsx
@@ -1,0 +1,33 @@
+import React, {useEffect} from "react"
+
+const CHATBOT_SCRIPT_ID = "chatbotscript"
+
+const LazyChatbotScript = (): null => {
+  useEffect(() => {
+    if (typeof window === "undefined" || document.getElementById(CHATBOT_SCRIPT_ID)) return
+
+    const loadScript = () => {
+      if (document.getElementById(CHATBOT_SCRIPT_ID)) return
+
+      const script = document.createElement("script")
+      script.id = CHATBOT_SCRIPT_ID
+      script.dataset.accountid = "CZPG9aVdtk59Tjz4SMTu8w=="
+      script.dataset.websiteid = "75VGI0NlBqessD4BQn2pFg=="
+      script.src = "https://app.robofy.ai/bot/js/common.js"
+      script.async = true
+      document.body.appendChild(script)
+    }
+
+    if ("requestIdleCallback" in window) {
+      const idleCallback = window.requestIdleCallback(loadScript, {timeout: 4000})
+      return () => window.cancelIdleCallback(idleCallback)
+    }
+
+    const timeout = setTimeout(loadScript, 2500)
+    return () => clearTimeout(timeout)
+  }, [])
+
+  return null
+}
+
+export default LazyChatbotScript


### PR DESCRIPTION
## Summary

Fixes #217.

This PR reduces homepage mobile Lighthouse pressure by deferring two expensive third-party/embed surfaces from the initial page load:

- moves the Robofy chatbot script out of Docusaurus `headTags` and loads it after browser idle time
- keeps the homepage introduction video as its existing thumbnail until the visitor clicks play, then loads the Vimeo iframe
- preserves the existing video behavior and cookie-based `dnt=1` handling when the iframe is created

## Validation

- `npm.cmd ci`
- `npm.cmd run build`

`npm.cmd run typecheck` still fails on existing unrelated repository type issues (`publish-externals/generated/graphql`, GraphiQL/DocSearch/Algolia typings). The new `LazyChatbotScript` type issue found during local validation was fixed before this PR.